### PR TITLE
Fix inference for generic in functor

### DIFF
--- a/sanctuary/sanctuary-types.d.ts
+++ b/sanctuary/sanctuary-types.d.ts
@@ -54,6 +54,7 @@ type NonZeroFiniteNumber = number; // - Infinity, -Infinity, 0, -0, NaN
 type ValidNumber = number; // - NaN
 
 export interface Functor<F> {
+  map<U>(fn: (f: F) => U): Functor<U>;
 }
 
 export interface MaybeFunc<M, N, T extends (m: M)=>N> extends Maybe<T> {

--- a/sanctuary/sanctuary-types.d.ts
+++ b/sanctuary/sanctuary-types.d.ts
@@ -54,7 +54,7 @@ type NonZeroFiniteNumber = number; // - Infinity, -Infinity, 0, -0, NaN
 type ValidNumber = number; // - NaN
 
 export interface Functor<F> {
-  map<U>(fn: (f: F) => U): Functor<U>;
+  'fantasy-land/map'<U>(fn: (f: F) => U): Functor<U>
 }
 
 export interface MaybeFunc<M, N, T extends (m: M)=>N> extends Maybe<T> {


### PR DESCRIPTION
Without describing how the generic F is used in the interface, there's no way for TypeScript to perform inference when a functor is provided.

Example:

``` ts
{
    const functor = {
        map: (fn: (x: string) => string) => functor
    }
    S.map(x => x.trim(), functor) // Property 'trim' does not exist on type '{}'.
}
```